### PR TITLE
Removed Play Count from Album, Artist, Playlist

### DIFF
--- a/packages/mock/models/songs.js
+++ b/packages/mock/models/songs.js
@@ -46,10 +46,11 @@ const connectSong = (source: SongSource, defaultStreamUrl: string): Song =>
 
 const songStats = ({
   id,
-  stats: { liked = false } = {},
+  stats: { liked = false, playCount = 0 } = {},
 }: SongSource): SongUserStats => ({
   id: songStatsId(id),
-  liked: liked,
+  playCount,
+  liked,
 });
 
 const songStatsId = (id: string): string => `${statsId(id)}:song`;

--- a/packages/mock/models/stats.js
+++ b/packages/mock/models/stats.js
@@ -4,12 +4,12 @@ import type { Song } from './songs';
 
 export type UserStats = {|
   id: string,
-  playCount: number,
   lastPlayed?: number,
 |};
 
 export type SongUserStats = {|
   id: string,
+  playCount: number,
   liked: boolean,
 |};
 
@@ -25,12 +25,11 @@ export const statsId = (parentId: string) => `${parentId}:stats`;
 
 export const withUserStats = ({
   id,
-  stats: { playCount = 0, lastPlayed } = {},
+  stats: { lastPlayed } = {},
 }: {
   id: string,
   +stats?: UserStatsSource,
 }): UserStats => ({
   id: statsId(id),
-  playCount: playCount,
   lastPlayed: lastPlayed,
 });

--- a/packages/mock/resolvers/mutation.js
+++ b/packages/mock/resolvers/mutation.js
@@ -27,8 +27,13 @@ const transformStats = (transform: (old: SongUserStats) => SongUserStats) =>
 
 const updateStats = (old: UserStats): UserStats => ({
   id: old.id,
-  playCount: old.playCount + 1,
   lastPlayed: now(),
+});
+
+const updateSongStats = (old: SongUserStats): SongUserStats => ({
+  id: old.id,
+  liked: old.liked,
+  playCount: old.playCount + 1,
 });
 
 export type PlaySongArgs = {
@@ -56,6 +61,7 @@ const playSong = (
 
   const song: Song = mustGet(songs, songId);
   song.stats = updateStats(song.stats);
+  song.songStats = updateSongStats(song.songStats);
 
   const album: Album | void = albumId ? mustGet(albums, albumId) : undefined;
   const artist: Artist | void = artistId
@@ -144,7 +150,11 @@ const deletePlaylist = (_: void, { playlistId }: { playlistId: string }) => {
 
 const mutation = {
   Mutation: {
-    toggleLike: transformStats(old => ({ id: old.id, liked: !old.liked })),
+    toggleLike: transformStats(old => ({
+      id: old.id,
+      playCount: old.playCount,
+      liked: !old.liked,
+    })),
     playSong,
     createPlaylist,
     updatePlaylist,

--- a/packages/mock/resolvers/sort.js
+++ b/packages/mock/resolvers/sort.js
@@ -7,7 +7,6 @@ type SortBy =
   | 'RECENTLY_ADDED'
   | 'LEXICOGRAPHICALLY'
   | 'RECENTLY_PLAYED'
-  | 'MOST_PLAYED'
   | 'RELEVANCE';
 
 type SortParams = {
@@ -135,11 +134,6 @@ export const listItemsResolver = <T>(
     case 'RECENTLY_PLAYED':
       sorter = (a: Sortable, b: Sortable) =>
         reverseCompare(a.stats.lastPlayed || 0, b.stats.lastPlayed || 0);
-      break;
-
-    case 'MOST_PLAYED':
-      sorter = (a: Sortable, b: Sortable) =>
-        reverseCompare(a.stats.playCount, b.stats.playCount);
       break;
 
     case 'RELEVANCE':

--- a/packages/schema/fixtures/stats.js
+++ b/packages/schema/fixtures/stats.js
@@ -1,9 +1,9 @@
 // @flow
 export type UserStats = {
-  playCount?: number,
   lastPlayed?: number,
 };
 
 export type SongUserStats = UserStats & {
+  playCount?: number,
   liked?: boolean,
 };

--- a/packages/schema/schema.graphql
+++ b/packages/schema/schema.graphql
@@ -98,9 +98,6 @@ type UserStats {
   # A globally unique id.
   id: ID!
 
-  # The number of times this item has been played.
-  playCount: Int!
-
   # The UTC epoch time (seconds) at which this item was last played. If the item
   # has never been played, this is null.
   lastPlayed: Int
@@ -110,6 +107,9 @@ type UserStats {
 type SongUserStats {
   # A globally unique id referring to a song's stats.
   id: ID!
+
+  # The number of times this item has been played.
+  playCount: Int!
 
   # Whether or not this song is liked. Liked songs go into their own
   # auto-playlist. By default this value is false. Updated by toggleLike
@@ -245,9 +245,6 @@ enum SortBy {
 
   # Sort from most recently played to least recently played.
   RECENTLY_PLAYED
-
-  # Sort from most played to least played.
-  MOST_PLAYED
 
   # Sort by how well the filter matches the item. If this is used
   # SortParams.filter must be specified.

--- a/packages/schema/tests/sort.js
+++ b/packages/schema/tests/sort.js
@@ -55,9 +55,5 @@ export const testSort = (testName, querySortable) => {
     t('RECENTLY_PLAYED', (a, b) =>
       reverseSort(a.stats.lastPlayed, b.stats.lastPlayed)
     );
-
-    t('MOST_PLAYED', (a, b) =>
-      reverseSort(a.stats.playCount, b.stats.playCount)
-    );
   });
 };

--- a/packages/schema/tests/tests/__snapshots__/song.js.snap
+++ b/packages/schema/tests/tests/__snapshots__/song.js.snap
@@ -30,11 +30,11 @@ Object {
     "songStats": Object {
       "id": "song:2:1:stats:song",
       "liked": false,
+      "playCount": 0,
     },
     "stats": Object {
       "id": "song:2:1:stats",
       "lastPlayed": null,
-      "playCount": 0,
     },
     "streamUrl": "/music/track.mp3",
     "trackNumber": 1,

--- a/packages/schema/tests/tests/fragments/SongUserStatsFields.graphql
+++ b/packages/schema/tests/tests/fragments/SongUserStatsFields.graphql
@@ -1,4 +1,5 @@
 fragment SongUserStatsFields on SongUserStats {
   id
+  playCount
   liked
 }

--- a/packages/schema/tests/tests/fragments/UserStatsFields.graphql
+++ b/packages/schema/tests/tests/fragments/UserStatsFields.graphql
@@ -1,5 +1,4 @@
 fragment UserStatsFields on UserStats {
   id
-  playCount
   lastPlayed
 }


### PR DESCRIPTION
It only really makes sense for the last played time to be stored and
exposed for these groups because the song count can be greater than the
album play count when the song is played from a playlist many times then
viewed in the album.

Also removed MOST_PLAYED sort. This is because there is no longer a
notion of most played album, artist and playlist. There can still be a
most played song. Maybe a smart playlist can be used to display songs
from most played to least played. This is not a priority.

Closes #34